### PR TITLE
Fix game info header blinking issue

### DIFF
--- a/feature-info/src/main/res/xml/scene_game_info_header.xml
+++ b/feature-info/src/main/res/xml/scene_game_info_header.xml
@@ -26,6 +26,9 @@
         <Constraint
             android:id="@id/artworksScrimView">
 
+            <PropertySet
+                android:visibility="invisible"/>
+
             <CustomAttribute
                 app:attributeName="backgroundColor"
                 app:customColorValue="@color/game_info_header_artworks_scrim_bg_color_expanded"/>
@@ -78,6 +81,9 @@
 
         <Constraint
             android:id="@id/artworksScrimView">
+
+            <PropertySet
+                android:visibility="visible"/>
 
             <CustomAttribute
                 app:attributeName="backgroundColor"


### PR DESCRIPTION
Fix an issue where game info header starts blinking when it reaches expanded state after opening a related game.