### PR TITLE
Fix a state bug with a heart icon of the like button

### DIFF
--- a/feature-info/src/main/java/com/paulrybitskyi/gamedge/feature/info/widgets/main/GameInfoView.kt
+++ b/feature-info/src/main/java/com/paulrybitskyi/gamedge/feature/info/widgets/main/GameInfoView.kt
@@ -267,4 +267,11 @@ internal class GameInfoView @JvmOverloads constructor(
     }
 
 
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+
+        headerController.onAttachedToWindow()
+    }
+
+
 }

--- a/feature-info/src/main/res/xml/scene_game_info_header.xml
+++ b/feature-info/src/main/res/xml/scene_game_info_header.xml
@@ -112,7 +112,7 @@
             android:id="@id/likeBtn">
 
             <PropertySet
-                android:visibility="invisible"/>
+                android:alpha="0"/>
 
         </Constraint>
 


### PR DESCRIPTION
Fix a bug, where a user likes a game, goes to a another screen (e.g., a related game) and comes back, then the like button resets its icon from a filled heart to an empty heart.