### PR TITLE
Hide page indicator completely when animation ends

### DIFF
--- a/feature-info/src/main/res/values/dimens.xml
+++ b/feature-info/src/main/res/values/dimens.xml
@@ -108,7 +108,7 @@
     <dimen name="game_info_header_page_indicator_horizontal_padding">8dp</dimen>
     <dimen name="game_info_header_page_indicator_background_radius">20dp</dimen>
     <dimen name="game_info_header_page_indicator_text_size">15sp</dimen>
-    <dimen name="game_info_header_page_indicator_transition_delta_x">50dp</dimen>
+    <dimen name="game_info_header_page_indicator_transition_delta_x">60dp</dimen>
     <dimen name="game_info_header_backdrop_elevation_expanded">2dp</dimen>
     <dimen name="game_info_header_backdrop_elevation_collapsed">4dp</dimen>
     <dimen name="game_info_header_backdrop_elevation">@dimen/game_info_header_backdrop_elevation_collapsed</dimen>

--- a/feature-info/src/main/res/xml/scene_game_info_header.xml
+++ b/feature-info/src/main/res/xml/scene_game_info_header.xml
@@ -290,11 +290,6 @@
                 app:motionTarget="@id/developerNameTv"/>
 
             <KeyAttribute
-                android:translationX="@dimen/game_info_header_page_indicator_transition_delta_x"
-                app:framePosition="60"
-                app:motionTarget="@id/pageIndicatorTv"/>
-
-            <KeyAttribute
                 android:alpha="0"
                 android:translationX="@dimen/game_info_header_cover_transition_delta_x"
                 android:translationY="@dimen/game_info_header_cover_transition_delta_y"
@@ -307,6 +302,11 @@
                 android:scaleY="0"
                 app:framePosition="60"
                 app:motionTarget="@id/likeBtn"/>
+
+            <KeyAttribute
+                android:translationX="@dimen/game_info_header_page_indicator_transition_delta_x"
+                app:framePosition="80"
+                app:motionTarget="@id/pageIndicatorTv"/>
 
             <KeyTrigger
                 app:triggerId="@+id/trimFirstTitle"


### PR DESCRIPTION
Fix a bug, where a page indicator was not fully hidden when the game info header had collapsed.