### PR TITLE
Disable sorting games by multiple columns

### DIFF
--- a/database/src/main/java/com/paulrybitskyi/gamedge/database/games/tables/GamesTable.kt
+++ b/database/src/main/java/com/paulrybitskyi/gamedge/database/games/tables/GamesTable.kt
@@ -65,7 +65,7 @@ internal interface GamesTable {
         WHERE ${Game.Schema.USERS_RATING} IS NOT NULL AND 
         ${Game.Schema.RELEASE_DATE} IS NOT NULL AND 
         ${Game.Schema.RELEASE_DATE} > :minReleaseDateTimestamp 
-        ORDER BY ${Game.Schema.TOTAL_RATING} DESC, ${Game.Schema.ID} ASC 
+        ORDER BY ${Game.Schema.TOTAL_RATING} DESC 
         LIMIT :offset, :limit
         """
     )
@@ -77,7 +77,7 @@ internal interface GamesTable {
         WHERE ${Game.Schema.RELEASE_DATE} IS NOT NULL AND 
         ${Game.Schema.RELEASE_DATE} > :minReleaseDateTimestamp AND 
         ${Game.Schema.RELEASE_DATE} < :maxReleaseDateTimestamp 
-        ORDER BY ${Game.Schema.RELEASE_DATE} DESC, ${Game.Schema.ID} ASC 
+        ORDER BY ${Game.Schema.RELEASE_DATE} DESC 
         LIMIT :offset, :limit
         """
     )
@@ -93,7 +93,7 @@ internal interface GamesTable {
         SELECT * FROM ${Game.Schema.TABLE_NAME} 
         WHERE ${Game.Schema.RELEASE_DATE} IS NOT NULL AND 
         ${Game.Schema.RELEASE_DATE} > :minReleaseDateTimestamp 
-        ORDER BY ${Game.Schema.RELEASE_DATE} ASC, ${Game.Schema.ID} ASC 
+        ORDER BY ${Game.Schema.RELEASE_DATE} ASC 
         LIMIT :offset, :limit
         """
     )
@@ -105,7 +105,7 @@ internal interface GamesTable {
         WHERE ${Game.Schema.RELEASE_DATE} IS NOT NULL AND 
         ${Game.Schema.RELEASE_DATE} > :minReleaseDateTimestamp AND 
         ${Game.Schema.HYPE_COUNT} IS NOT NULL 
-        ORDER BY ${Game.Schema.HYPE_COUNT} DESC, ${Game.Schema.ID} ASC 
+        ORDER BY ${Game.Schema.HYPE_COUNT} DESC 
         LIMIT :offset, :limit
         """
     )


### PR DESCRIPTION
Multiple column sorting is disabled for games due to the fact that it can cause issues in the UI layer when loading paginated results into a widget like RecyclerView. For example, let's say a page of 20 games sorted by a field "first_release_date" are loaded into the RecyclerView. The last 20th item may have the field "first_release_date" equal to 1000. What we don't know is that the 21st, 22nd, 23rd (which have not been downloaded from the server yet) and so on may have the same field equal to 1000. Since the IGDB API allows us to sort only by one column and we sort in the database by multiple columns, this means that when new pages are loaded into the RecyclerView, a user will see RecyclerView reordering items, which is undesirable at the moment.