### PR TITLE
Hide InfoView when performing subsequent game searches

### DIFF
--- a/commons-ui-widgets/src/main/java/com/paulrybitskyi/gamedge/commons/ui/widgets/games/GamesView.kt
+++ b/commons-ui-widgets/src/main/java/com/paulrybitskyi/gamedge/commons/ui/widgets/games/GamesView.kt
@@ -130,6 +130,11 @@ class GamesView @JvmOverloads constructor(
     }
 
 
+    fun clearItems() {
+        adapterItems = emptyList()
+    }
+
+
     private fun List<GameModel>.toAdapterItems(): List<GameItem> {
         return map(::GameItem)
     }
@@ -145,8 +150,6 @@ class GamesView @JvmOverloads constructor(
 
 
     private fun onEmptyUiStateSelected(uiState: GamesUiState.Empty) {
-        adapterItems = emptyList()
-
         showInfoView(uiState)
         hideLoadingIndicators()
         hideRecyclerView()

--- a/feature-search/src/main/java/com/paulrybitskyi/gamedge/feature/search/GamesSearchEffects.kt
+++ b/feature-search/src/main/java/com/paulrybitskyi/gamedge/feature/search/GamesSearchEffects.kt
@@ -16,7 +16,15 @@
 
 package com.paulrybitskyi.gamedge.feature.search
 
+import com.paulrybitskyi.gamedge.commons.ui.base.events.Command
 import com.paulrybitskyi.gamedge.commons.ui.base.events.Route
+
+
+internal sealed class GamesSearchCommand : Command {
+
+    object ClearItems : GamesSearchCommand()
+
+}
 
 
 internal sealed class GamesSearchRoute : Route {

--- a/feature-search/src/main/java/com/paulrybitskyi/gamedge/feature/search/GamesSearchFragment.kt
+++ b/feature-search/src/main/java/com/paulrybitskyi/gamedge/feature/search/GamesSearchFragment.kt
@@ -22,6 +22,7 @@ import com.paulrybitskyi.commons.ktx.applyWindowBottomInsetAsMargin
 import com.paulrybitskyi.commons.ktx.applyWindowTopInsetAsPadding
 import com.paulrybitskyi.commons.utils.viewBinding
 import com.paulrybitskyi.gamedge.commons.ui.base.BaseFragment
+import com.paulrybitskyi.gamedge.commons.ui.base.events.Command
 import com.paulrybitskyi.gamedge.commons.ui.base.events.Route
 import com.paulrybitskyi.gamedge.commons.ui.observeIn
 import com.paulrybitskyi.gamedge.feature.search.databinding.FragmentGamesSearchBinding
@@ -93,6 +94,15 @@ internal class GamesSearchFragment : BaseFragment<
         super.onPause()
 
         viewBinding.searchToolbar.hideKeyboard()
+    }
+
+
+    override fun onHandleCommand(command: Command) {
+        super.onHandleCommand(command)
+
+        when(command) {
+            is GamesSearchCommand.ClearItems -> viewBinding.gamesView.clearItems()
+        }
     }
 
 

--- a/feature-search/src/main/java/com/paulrybitskyi/gamedge/feature/search/GamesSearchViewModel.kt
+++ b/feature-search/src/main/java/com/paulrybitskyi/gamedge/feature/search/GamesSearchViewModel.kt
@@ -30,7 +30,6 @@ import com.paulrybitskyi.gamedge.domain.commons.entities.nextPage
 import com.paulrybitskyi.gamedge.domain.games.entities.Game
 import com.paulrybitskyi.gamedge.domain.games.usecases.SearchGamesUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -84,10 +83,7 @@ internal class GamesSearchViewModel @Inject constructor(
                 }
                 .onStart {
                     if(!isPaginationRelatedLoad()) {
-                        emit(createEmptyGamesUiState())
-                        // Intentional delay since the fragment does not seem
-                        // to pick the empty state up
-                        delay(10L)
+                        dispatchCommand(GamesSearchCommand.ClearItems)
                     }
 
                     emit(gamesSearchUiStateFactory.createWithLoadingState())


### PR DESCRIPTION
When performing subsequent (after the first one) game searches, the GamesView will show real quick the InfoView before showing a loading indicator. This is undersirable and this PR eliminates that flickering.